### PR TITLE
Change the order of the bower dependencies for minification fixes

### DIFF
--- a/src/client/app/bowers.jade
+++ b/src/client/app/bowers.jade
@@ -9,13 +9,13 @@
 - bowers.push('/bower_components/moment/moment')
 - bowers.push('/bower_components/angular-ui-router/release/angular-ui-router')
 - bowers.push('/bower_components/toastr/toastr')
+- bowers.push("/bower_components/angular-scroll/angular-scroll")
 - bowers.push('/bower_components/auth0.js/build/auth0')
 - bowers.push('/bower_components/angular-animate/angular-animate')
 - bowers.push('/bower_components/angular-cookies/angular-cookies')
 - bowers.push('/bower_components/auth0-lock/build/auth0-lock')
 - bowers.push('/bower_components/a0-angular-storage/dist/angular-storage')
 - bowers.push('/bower_components/auth0-angular/build/auth0-angular')
-- bowers.push("/bower_components/angular-scroll/angular-scroll")
 
 - var bowercss = []
 - bowercss.push('/bower_components/font-awesome/css/font-awesome')


### PR DESCRIPTION
Change the order of the bower dependencies for minification fixes

@vietnogi @tladendo 

Minification breaks if the auth0 stuff isn't last.